### PR TITLE
[Improvement] Thread Safety using Concurrent HashMap

### DIFF
--- a/src/main/java/org/wso2/apim/mediators/oauth/TokenCache.java
+++ b/src/main/java/org/wso2/apim/mediators/oauth/TokenCache.java
@@ -14,8 +14,8 @@
 
 package org.wso2.apim.mediators.oauth;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Token cache implementation.
@@ -24,7 +24,7 @@ public class TokenCache {
 
     private static final TokenCache instance = new TokenCache();
 
-    private final Map<String, String> tokenMap = new HashMap<>();
+    private final Map<String, String> tokenMap = new ConcurrentHashMap<String, String>();
 
     /**
      * Private constructor.


### PR DESCRIPTION
### Description

`HashMap<>` usages in the `TokenCache` class is changed to `ConcurrentHashMap<String, String>()` considering Thread Safety execution.